### PR TITLE
Add missing directory test

### DIFF
--- a/src/tools/prompt_tool.test.ts
+++ b/src/tools/prompt_tool.test.ts
@@ -68,6 +68,18 @@ describe("fetchPromptTemplate", () => {
     );
   });
 
+  it("should handle a missing prompts directory", async () => {
+    const error = new Error("File not found");
+    (error as any).code = "ENOENT";
+    (fs.readFile as jest.Mock).mockRejectedValue(error);
+
+    (fs.readdir as jest.Mock).mockRejectedValue(new Error("directory missing"));
+
+    await expect(fetchPromptTemplate("missing")).rejects.toThrow(
+      'Prompt "missing" not found. No prompts found.'
+    );
+  });
+
   it("should throw a generic error if an unexpected error occurs", async () => {
     // Mock readFile to throw a different error
     const error = new Error("Permission denied");


### PR DESCRIPTION
## Summary
- add test to assert proper error when prompts directory is missing
- revert accidental changes to `package-lock.json`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6840458ad874832eaee13c27e76b204d