### PR TITLE
Disable version check in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
         docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
-        fail-on-existing: 'true'
+        fail-on-existing: 'false'
       
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- avoid failing builds when version already exists by setting `fail-on-existing` to `false` in CI workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404cf17c08832ebbeefe03d3a38d0c